### PR TITLE
Don't register MainThreadScheduler when in unit tests.

### DIFF
--- a/src/ReactiveUI.Wpf/Registrations.cs
+++ b/src/ReactiveUI.Wpf/Registrations.cs
@@ -20,7 +20,9 @@ namespace ReactiveUI.Wpf
 
             RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
 
-            RxApp.MainThreadScheduler = new WaitForDispatcherScheduler(() => DispatcherScheduler.Current);
+            if (!Splat.ModeDetector.InUnitTestRunner()) {
+                RxApp.MainThreadScheduler = new WaitForDispatcherScheduler(() => DispatcherScheduler.Current);
+            }
         }
     }
 }

--- a/src/ReactiveUI/Platforms/net461/PlatformRegistrations.cs
+++ b/src/ReactiveUI/Platforms/net461/PlatformRegistrations.cs
@@ -13,7 +13,10 @@ namespace ReactiveUI
         {
             registerFunction(() => new ComponentModelTypeConverter(), typeof(IBindingTypeConverter));
             RxApp.TaskpoolScheduler = TaskPoolScheduler.Default;
-            RxApp.MainThreadScheduler = DefaultScheduler.Instance;
+
+            if (!Splat.ModeDetector.InUnitTestRunner()) {
+                RxApp.MainThreadScheduler = DefaultScheduler.Instance;
+            }
         }
     }
 }


### PR DESCRIPTION
Unit tests require a `CurrentThreadScheduler` to be used, the platform registrations were overriding that, causing intermittent test failures as commands were being scheduled on the dispatcher.
